### PR TITLE
Add support for a range of elasticsearch and redis

### DIFF
--- a/requirements/modules/flask_plugins.txt
+++ b/requirements/modules/flask_plugins.txt
@@ -1,7 +1,7 @@
 eswrap~=0.5.0
-redis~=5.0.1
+redis>=4.6.0
 kafka-python~=2.0.2
-elasticsearch~=8.10.0
+elasticsearch>=8.7.0
 flask~=2.3.3
 SQLAlchemy~=2.0.21
 Flask_SQLAlchemy~=3.1.1


### PR DESCRIPTION
Redis and Elasticsearch dependencies were very strict. Elasticsearch 8.7.0 clashed with the requirements for eswrap and Redis clashed with celery[redis]. Gave pip some more freedom to sort things out for us.