### PR TITLE
Add extra output types ApiBaseClass.call

### DIFF
--- a/nldcsc/http_apis/base_class/api_base_class.py
+++ b/nldcsc/http_apis/base_class/api_base_class.py
@@ -153,7 +153,7 @@ class ApiBaseClass(object):
         data: dict = None,
         timeout: int = 60,
         return_response_object=False,
-    ) -> dict:
+    ) -> Response | str | Any:
         """
         Method for requesting free format api resources
 


### PR DESCRIPTION
Tiny fix but my IDE is complaining about output types when .call is used with return_response_object.