### PR TITLE
Add missing module to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ MODULES = {
     "auth",
     "datatables",
     "flask_managers",
+    "flask_middleware",
     "flask_plugins",
     "http_apis",
     "loggers",


### PR DESCRIPTION
Came across a missing rfc3339 requirement in the new debug_logging middleware in Racoon.