### PR TITLE
Add option to config eswrap and redis plugins without app

### DIFF
--- a/nldcsc/flask_plugins/flask_eswrap.py
+++ b/nldcsc/flask_plugins/flask_eswrap.py
@@ -6,7 +6,7 @@ from nldcsc.generic.utils import getenv_list, getenv_dict
 
 
 class FlaskEsWrap(object):
-    def __init__(self, app=None, **kwargs):
+    def __init__(self, app=None, ignore_app_init: bool = False, **kwargs):
         self._es = None
         self.kwargs = kwargs
 
@@ -26,8 +26,9 @@ class FlaskEsWrap(object):
         )
         self.elastic_kwargs = getenv_dict("ELASTIC_KWARGS", None)
 
-        if app is not None:
+        if app is not None or ignore_app_init:
             self.init_app(app)
+        
 
     def init_app(self, app, **kwargs):
         self.kwargs.update(kwargs)
@@ -67,7 +68,8 @@ class FlaskEsWrap(object):
                     **self.kwargs if self.kwargs is not None else {},
                 )
 
-        app.flask_eswrap = self
+        if app is not None:
+            app.flask_eswrap = self
 
     @property
     def es(self):

--- a/nldcsc/flask_plugins/flask_eswrap.py
+++ b/nldcsc/flask_plugins/flask_eswrap.py
@@ -6,7 +6,10 @@ from nldcsc.generic.utils import getenv_list, getenv_dict
 
 
 class FlaskEsWrap(object):
-    def __init__(self, app=None, ignore_app_init: bool = False, **kwargs):
+    def __init__(self, app=None, init_standalone: bool = False, **kwargs):
+        if app and init_standalone:
+            raise Exception("App must be None when 'ignore_app_init' is set to True")
+
         self._es = None
         self.kwargs = kwargs
 
@@ -26,7 +29,7 @@ class FlaskEsWrap(object):
         )
         self.elastic_kwargs = getenv_dict("ELASTIC_KWARGS", None)
 
-        if app is not None or ignore_app_init:
+        if app is not None or init_standalone:
             self.init_app(app)
         
 

--- a/nldcsc/flask_plugins/flask_redis.py
+++ b/nldcsc/flask_plugins/flask_redis.py
@@ -7,7 +7,7 @@ from nldcsc.generic.utils import getenv_dict
 
 
 class FlaskRedis(object):
-    def __init__(self, app=None, redis_url: str = None, **kwargs):
+    def __init__(self, app=None, ignore_app_init: bool = False, redis_url: str = None, **kwargs):
         self._redis_client = None
         self.kwargs = kwargs
         self.redis_url = (
@@ -19,7 +19,7 @@ class FlaskRedis(object):
         self.redis_cache_db = int(os.getenv("REDIS_CACHE_DB", 0))
         self.redis_kwargs = getenv_dict("REDIS_KWARGS", None)
 
-        if app is not None:
+        if app is not None or ignore_app_init:
             self.init_app(app)
 
     def init_app(self, app, **kwargs):
@@ -37,7 +37,8 @@ class FlaskRedis(object):
             **self.kwargs,
         )
 
-        app.redis_client = self
+        if app is not None:
+            app.redis_client = self
 
     def __repr__(self):
         return "<< FlaskRedis >>"

--- a/nldcsc/flask_plugins/flask_redis.py
+++ b/nldcsc/flask_plugins/flask_redis.py
@@ -7,7 +7,10 @@ from nldcsc.generic.utils import getenv_dict
 
 
 class FlaskRedis(object):
-    def __init__(self, app=None, ignore_app_init: bool = False, redis_url: str = None, **kwargs):
+    def __init__(self, app=None, init_standalone: bool = False, redis_url: str = None, **kwargs):
+        if app and init_standalone:
+            raise Exception("App must be None when 'init_standalone' is set to True")
+
         self._redis_client = None
         self.kwargs = kwargs
         self.redis_url = (
@@ -19,7 +22,7 @@ class FlaskRedis(object):
         self.redis_cache_db = int(os.getenv("REDIS_CACHE_DB", 0))
         self.redis_kwargs = getenv_dict("REDIS_KWARGS", None)
 
-        if app is not None or ignore_app_init:
+        if app is not None or init_standalone:
             self.init_app(app)
 
     def init_app(self, app, **kwargs):


### PR DESCRIPTION
 I need to use flaskeswrap in the celery daemon, I don't want to introduce the app context and I don't want to duplicate the configuration in a second elasticsearch class in Racoon's racoon_daemon.py or some helper plugin if we already have a class suitable for it.  

By ignoring the app parameter a plugin can be reused for other purposes within the same project, this is especially handy if the plugin is already in use within the flask context. I only need eswrap for now but did redis just in case. I can also do this for the kafka plugin later.