### PR TITLE
fix bug in app manager

### DIFF
--- a/nldcsc/__init__.py
+++ b/nldcsc/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.25"
+__version__ = "0.2.26"
 __author__ = "NLDCSC"

--- a/nldcsc/flask_managers/flask_app_manager.py
+++ b/nldcsc/flask_managers/flask_app_manager.py
@@ -95,7 +95,7 @@ class FlaskAppManager(object):
                         os.path.join(self.app_working_dir, "INIT_COMPLETED")
                     ):
                         fsm = FlaskSqlMigrate(
-                            cwd=self.app.instance_path.rstrip("/instance"),
+                            cwd=self.app.instance_path.replace("/instance", ""),
                             app_ref=self.app.import_name,
                         )
 


### PR DESCRIPTION
`"racoon/instance".rstrip("/instance")` doesnt (just) remove "/instance". It strips any characters from the right that match any characters in "/instance". Which also matches, for example, the "n", leading to ".../racoo" directory not found errors when setting up a new project.