### PR TITLE
Update requirements for auth module

### DIFF
--- a/requirements/modules/auth.txt
+++ b/requirements/modules/auth.txt
@@ -1,1 +1,2 @@
 python-ldap>=3.4.3
+-r ./loggers.txt


### PR DESCRIPTION
# Import error when installing `auth` only

Auth imports the `colors` package.
Found it in the loggers dep. 

## Proposed Changes:

install `loggers.txt` reqs with auth.

 
## Solves

Import error when:
```bash
pip install "nldcsc[auth]" 
```