### PR TITLE
Flask sqlalchemy wrap

### DIFF
--- a/nldcsc/flask_plugins/flask_sqlalchemy/__init__.py
+++ b/nldcsc/flask_plugins/flask_sqlalchemy/__init__.py
@@ -1,0 +1,16 @@
+from .flask_sqlalchemy import FlaskSQLAlchemy  # noqa: F401
+from .annotations import (
+    str_16,  # noqa: F401
+    str_30,  # noqa: F401
+    str_50,  # noqa: F401
+    str_64,  # noqa: F401
+    str_100,  # noqa: F401
+    str_128,  # noqa: F401
+    str_256,  # noqa: F401
+    str_512,  # noqa: F401
+    str_text,  # noqa: F401
+    list_json,  # noqa: F401
+    dict_json,  # noqa: F401
+    int_pk,  # noqa: F401
+    big_int_pk,  # noqa: F401
+)

--- a/nldcsc/flask_plugins/flask_sqlalchemy/annotations.py
+++ b/nldcsc/flask_plugins/flask_sqlalchemy/annotations.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from typing_extensions import Annotated
+from sqlalchemy.orm import mapped_column
+
+# this file should contain all common annotations used:
+# - to keep things consistent the naming convention should be <type>_<identifier> -> str_64, str_128, int_pk, etc.
+
+# ints
+int_pk = Annotated[int, mapped_column(primary_key=True)]
+big_int_pk = Annotated[int, mapped_column(primary_key=True)]
+
+# strings
+str_16 = Annotated[str, 16]
+str_30 = Annotated[str, 30]
+str_50 = Annotated[str, 50]
+str_64 = Annotated[str, 64]
+str_100 = Annotated[str, 100]
+str_128 = Annotated[str, 128]
+str_256 = Annotated[str, 256]
+str_512 = Annotated[str, 512]
+str_text = str
+
+# dicts
+dict_json = dict[str, Any]
+
+# lists
+list_json = list[Any]

--- a/nldcsc/flask_plugins/flask_sqlalchemy/flask_sqlalchemy.py
+++ b/nldcsc/flask_plugins/flask_sqlalchemy/flask_sqlalchemy.py
@@ -1,6 +1,4 @@
-from functools import wraps
 from flask_sqlalchemy import SQLAlchemy
-
 
 from .model_base import ModelBase
 

--- a/nldcsc/flask_plugins/flask_sqlalchemy/flask_sqlalchemy.py
+++ b/nldcsc/flask_plugins/flask_sqlalchemy/flask_sqlalchemy.py
@@ -1,0 +1,17 @@
+from functools import wraps
+from flask_sqlalchemy import SQLAlchemy
+
+
+from .model_base import ModelBase
+
+
+class FlaskSQLAlchemy(SQLAlchemy):
+    def __init__(self, *args, **kwargs):
+        base_class = kwargs.pop("model_class", None)
+
+        if base_class is None:
+            base_class = ModelBase
+
+        kwargs["model_class"] = base_class
+
+        super().__init__(*args, **kwargs)

--- a/nldcsc/flask_plugins/flask_sqlalchemy/model_base.py
+++ b/nldcsc/flask_plugins/flask_sqlalchemy/model_base.py
@@ -1,0 +1,35 @@
+from sqlalchemy import JSON, TEXT, BigInteger, String
+from sqlalchemy.orm import DeclarativeBase, registry
+from .annotations import (
+    str_16,
+    str_30,
+    str_50,
+    str_64,
+    str_100,
+    str_128,
+    str_256,
+    str_512,
+    str_text,
+    list_json,
+    dict_json,
+    big_int_pk,
+)
+
+
+class ModelBase(DeclarativeBase):
+    registry = registry(
+        type_annotation_map={
+            str_16: String(16),
+            str_30: String(30),
+            str_50: String(50),
+            str_64: String(64),
+            str_100: String(100),
+            str_128: String(128),
+            str_256: String(256),
+            str_512: String(512),
+            str_text: TEXT,
+            dict_json: JSON,
+            list_json: JSON,
+            big_int_pk: BigInteger,
+        },
+    )


### PR DESCRIPTION
Makes use of SQLAlchemy 2.0 models easier across projects by wrapping the Flask-SQLAlchemy default class.

@P-T-I What do you think of putting this in the NLDCSC package? This should reduce the duplication of this code by quite a few times. However, it may create the effect that if a new type is needed this needs to be updated in this package first or on the models own type_annotation_map.

LMK what you think!
