### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov_check.yaml
+++ b/.github/workflows/codecov_check.yaml
@@ -5,6 +5,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/NLDCSC/nldcsc/security/code-scanning/16](https://github.com/NLDCSC/nldcsc/security/code-scanning/16)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `run`) unless overridden. The least-privilege baseline for this workflow is `contents: read`, which is sufficient for checkout and running tests. This directly resolves the CodeQL finding without changing workflow behavior.

Edit only `.github/workflows/codecov_check.yaml`, inserting:

```yaml
permissions:
  contents: read
```

immediately after the trigger section (`on:` block) and before `jobs:`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
