### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package_to_pypi.yaml
+++ b/.github/workflows/package_to_pypi.yaml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   release:
-    permissions: write-all
+    permissions:
+      contents: write
     name: Create Release
     runs-on: ubuntu-latest
     steps:
@@ -35,6 +36,8 @@ jobs:
           prerelease: false
   build:
     needs: release
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
@@ -59,6 +62,7 @@ jobs:
     needs:
       - build
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Retrieve release distributions


### PR DESCRIPTION
Potential fix for [https://github.com/NLDCSC/nldcsc/security/code-scanning/17](https://github.com/NLDCSC/nldcsc/security/code-scanning/17)

Add explicit, least-privilege `permissions` per job in `.github/workflows/package_to_pypi.yaml`:

- Replace `release` job’s `permissions: write-all` with only what it needs to create a GitHub release and read repo contents.
  - `contents: write` (required for creating release/tag metadata via `softprops/action-gh-release`)
- Add a `permissions` block to `build` with read-only access:
  - `contents: read` (sufficient for checkout/build steps)
- Keep `pypi-publish` `id-token: write` and add `contents: read` explicitly for clarity and consistency.

This preserves functionality while removing excessive/default privilege reliance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
